### PR TITLE
Optimize API Calls

### DIFF
--- a/BBQuotes/Screens/QuoteEpisode/ViewModels/QuoteEpisodeViewModel.swift
+++ b/BBQuotes/Screens/QuoteEpisode/ViewModels/QuoteEpisodeViewModel.swift
@@ -21,9 +21,15 @@ import Foundation
     var character: Character?
     var episode: Episode?
     var fetchStatus = DataFetchStatus.idle
+    private var isInitialLoad = true
 
     init(client: APIClientProtocol = APIClient()) {
         self.client = client
+    }
+
+    func shouldInitialLoad() -> Bool {
+        defer { isInitialLoad = false }
+        return isInitialLoad
     }
 
     func fetchQuoteData(for production: Production) async {

--- a/BBQuotes/Screens/QuoteEpisode/Views/QuoteEpisodeView.swift
+++ b/BBQuotes/Screens/QuoteEpisode/Views/QuoteEpisodeView.swift
@@ -17,10 +17,6 @@ struct QuoteEpisodeView: View {
     init(production: Production, viewModel: QuoteEpisodeViewModel = QuoteEpisodeViewModel()) {
         self.production = production
         self.viewModel = viewModel
-
-        Task {
-            await viewModel.fetchQuoteData(for: production)
-        }
     }
 
     // MARK: - Views
@@ -103,6 +99,11 @@ struct QuoteEpisodeView: View {
                 CharacterView(production: production, character: character)
             } else {
                 ProgressView()
+            }
+        }
+        .task {
+            if viewModel.shouldInitialLoad() {
+                await viewModel.fetchQuoteData(for: production)
             }
         }
     }


### PR DESCRIPTION
# Problem
Currently, when the app launches, it makes API calls for all three tabs simultaneously, even though only one tab is active. 

By adding print statements in `APIClient.makeRequest`, you can observe the unnecessary network requests:

```
// Breaking Bad tab
make request: .../api/quotes/random?production=Breaking%20Bad
make request: .../api/characters?name=Walter%20White
make request: .../api/deaths

// Better Call Saul tab (not active)
make request: .../api/quotes/random?production=Better%20Call%20Saul
make request: .../api/characters?name=Jimmy%20McGill
make request: .../api/deaths

// El Camino tab (not active)
make request: .../api/quotes/random?production=El%20Camino
make request: .../api/characters?name=Badger
make request: .../api/deaths
```


# Solution
1. Remove API calls from init to prevent eager loading
2. Add `isInitialLoad` flag to control initial data fetching
3. Use .task modifier to handle API calls lifecycle properly (Why chose .task over Task? -> view my note: [Task vs .task in SwiftUI Async Operations](https://publish.obsidian.md/uhcakip/Apple+Dev/Highlights/Courses/The+Ultimate+70%2B+Hours+iOS+Development+Bootcamp/51.+Refactoring+and+Displaying+Weather+on+the+Screen#Task+vs.+%60.task%60+in+SwiftUI+Async+Operations))

When app launches, it only makes 3 API calls for the active tab:

```
// Only Breaking Bad tab (active)
make request: .../api/quotes/random?production=Breaking%20Bad
make request: .../api/characters?name=Walter%20White
make request: .../api/deaths
```